### PR TITLE
Add vehicle photo preview to booking form

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,15 +1,51 @@
 // Application data
 const appData = {
   vehicles: [
-    {label: "AUDI A6", price: 16000},
-    {label: "BMW 330 D Convertible", price: 26000},
-    {label: "BMW 5 Series F10 (Old Shape)", price: 16000},
-    {label: "BMW 520D", price: 16000},
-    {label: "BMW 5 SERIES G30 (New Shape)", price: 24000},
-    {label: "Mercedes G-Wagon", price: 132000},
-    {label: "MERCEDES Maybach", price: 85000},
-    {label: "MERCEDES S-CLASS S350", price: 18000},
-    {label: "Range Rover Sport", price: 85000}
+    {
+      label: "AUDI A6",
+      price: 16000,
+      image: "https://i.postimg.cc/zfxy8jD7/AUDI-A6.jpg"
+    },
+    {
+      label: "BMW 330 D Convertible",
+      price: 26000,
+      image: "https://i.postimg.cc/L4nyP974/BMW-330-D-Convertible.jpg"
+    },
+    {
+      label: "BMW 5 Series F10 (Old Shape)",
+      price: 16000,
+      image: "https://i.postimg.cc/zvgvwYC2/BMW-5-Series-F10-OLD-SHAPE.jpg"
+    },
+    {
+      label: "BMW 520D",
+      price: 16000,
+      image: "https://i.postimg.cc/26dwqh2j/BMW-520D.jpg"
+    },
+    {
+      label: "BMW 5 SERIES G30 (New Shape)",
+      price: 24000,
+      image: "https://i.postimg.cc/Hj1xBv3Y/BMW-5-SERIES-G30-New-shape.jpg"
+    },
+    {
+      label: "Mercedes G-Wagon",
+      price: 132000,
+      image: "https://i.postimg.cc/J7vp5wVN/Mercedes-G-wagon.jpg"
+    },
+    {
+      label: "MERCEDES Maybach",
+      price: 85000,
+      image: "https://i.postimg.cc/MKBdssqh/MERCEDES-Maybach.jpg"
+    },
+    {
+      label: "MERCEDES S-CLASS S350",
+      price: 18000,
+      image: "https://i.postimg.cc/cLNTPQJ6/MERCEDES-S-CLASS-S350.jpg"
+    },
+    {
+      label: "Range Rover Sport",
+      price: 85000,
+      image: "https://i.postimg.cc/rwCgTKdj/Range-Rover-Sport.jpg"
+    }
   ],
   decorations: [
     {label: "No", price: 0},
@@ -56,6 +92,9 @@ const priceEstimation = document.getElementById('priceEstimation');
 const summaryContent = document.getElementById('summaryContent');
 const whatsappBtn = document.getElementById('whatsappBtn');
 const eventDateInput = document.getElementById('eventDate');
+const vehiclePreview = document.getElementById('vehiclePreview');
+const vehicleImage = document.getElementById('vehicleImage');
+const vehicleImageCaption = document.getElementById('vehicleImageCaption');
 
 // Initialize the application
 document.addEventListener('DOMContentLoaded', function() {
@@ -67,6 +106,7 @@ function initializeApp() {
   setMinDate();
   attachEventListeners();
   updateSummary(); // Initial update
+  updateVehiclePreview();
 }
 
 function populateVehicleOptions() {
@@ -114,6 +154,9 @@ function handleFormChange(e) {
   updateBookingState(e);
   updateSummary();
   updatePriceEstimation();
+  if (e.target.name === 'vehicle') {
+    updateVehiclePreview();
+  }
 }
 
 function handleFormInput(e) {
@@ -121,6 +164,9 @@ function handleFormInput(e) {
   updateSummary();
   if (['startLocation', 'endLocation'].includes(e.target.name)) {
     updatePriceEstimation();
+  }
+  if (e.target.name === 'vehicle') {
+    updateVehiclePreview();
   }
 }
 
@@ -137,6 +183,24 @@ function updateBookingState(e) {
     }
   } else {
     bookingState[name] = value;
+  }
+}
+
+function updateVehiclePreview() {
+  if (!vehiclePreview || !vehicleImage || !vehicleImageCaption) {
+    return;
+  }
+
+  if (bookingState.vehicle && bookingState.vehicle.image) {
+    vehiclePreview.classList.remove('hidden');
+    vehicleImage.src = bookingState.vehicle.image;
+    vehicleImage.alt = `${bookingState.vehicle.label} - Valley Wedding Cars`;
+    vehicleImageCaption.textContent = bookingState.vehicle.label;
+  } else {
+    vehiclePreview.classList.add('hidden');
+    vehicleImage.src = '';
+    vehicleImage.alt = '';
+    vehicleImageCaption.textContent = '';
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -153,6 +153,12 @@
                                     <option value="">Choose a vehicle...</option>
                                 </select>
                             </div>
+                            <div id="vehiclePreview" class="vehicle-preview hidden" aria-live="polite">
+                                <div class="vehicle-preview__image-wrapper">
+                                    <img id="vehicleImage" class="vehicle-preview__image" alt="" loading="lazy" />
+                                </div>
+                                <p id="vehicleImageCaption" class="vehicle-preview__caption"></p>
+                            </div>
                         </div>
 
                         <!-- Date & Time -->

--- a/style.css
+++ b/style.css
@@ -539,6 +539,51 @@ select.form-control {
   margin-bottom: var(--space-16);
 }
 
+.vehicle-preview {
+  margin-top: var(--space-16);
+  border: 1px solid var(--color-card-border);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(
+    135deg,
+    rgba(var(--color-brown-600-rgb), 0.12) 0%,
+    rgba(var(--color-brown-600-rgb), 0.08) 100%
+  );
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+  transition: transform var(--duration-normal) var(--ease-standard),
+    box-shadow var(--duration-normal) var(--ease-standard);
+}
+
+.vehicle-preview:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.vehicle-preview__image-wrapper {
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%;
+  overflow: hidden;
+  background: rgba(var(--color-brown-600-rgb), 0.06);
+}
+
+.vehicle-preview__image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.vehicle-preview__caption {
+  margin: var(--space-12);
+  text-align: center;
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+}
+
 /* Card component */
 .card {
   background-color: var(--color-surface);


### PR DESCRIPTION
## Summary
- add hosted image URLs to each vehicle option and render a preview panel in the booking form
- update the client logic to toggle the preview automatically as customers choose different cars
- style the preview card to match the existing gold-on-black aesthetic

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e4e8c6ca60832d826a11211cf7c126